### PR TITLE
fix: load PrismaPlugin only if CI environment

### DIFF
--- a/apps/platform/next.config.mjs
+++ b/apps/platform/next.config.mjs
@@ -2,12 +2,14 @@ import { PrismaPlugin } from '@prisma/nextjs-monorepo-workaround-plugin';
 import createNextIntlPlugin from 'next-intl/plugin';
 import path from 'path';
 
+const isDeployed = process.env.CI === '1';
+
 const withNextIntl = createNextIntlPlugin();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   webpack: (config, { isServer }) => {
-    if (isServer) {
+    if (isServer && isDeployed) {
       config.plugins = [...config.plugins, new PrismaPlugin()]
     }
     config.resolve.fallback = { fs: false, net: false, tls: false };


### PR DESCRIPTION
- has issues with loading .env
- breaks loading DATABASE_URL in a local build environment