### PR TITLE
fix: Enhance db management scripts and seeding process

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,7 +13,7 @@
     ".": "./index.ts"
   },
   "scripts": {
-    "postinstall": "prisma generate",
+    "postinstall": "prisma generate && prisma migrate deploy && prisma db seed",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,6 +14,11 @@
   },
   "scripts": {
     "postinstall": "prisma generate && prisma migrate deploy && prisma db seed",
+    "db:generate": "prisma generate",
+    "db:migrate:dev": "prisma migrate dev",
+    "db:seed": "ts-node prisma/seed.ts",
+    "db:reset": "prisma migrate reset",
+    "nuke": "prisma migrate reset --force",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,8 +1,24 @@
 import { prisma } from '../lib/client';
 import seedRoundPhases from './seeds/round-phases';
 
+const alwaysRunSeeds = [
+  seedRoundPhases,
+];
+
+const nonCISeeds: ((() => Promise<void>)[]) = [
+  // Add any seeds that should not run in CI environment
+];
+
 async function seed() {
-  await seedRoundPhases();
+  const seedsToRun = [...alwaysRunSeeds];
+
+  if (!process.env.CI) {
+    seedsToRun.push(...nonCISeeds);
+  }
+
+  for (const seedFn of seedsToRun) {
+    await seedFn();
+  }
 }
 
 seed()

--- a/packages/db/prisma/seeds/round-phases.ts
+++ b/packages/db/prisma/seeds/round-phases.ts
@@ -24,6 +24,13 @@ const roundPhases = [
 ];
 
 export default async function seedRoundPhases() {
+  const existingPhases = await prisma.roundPhase.findMany();
+  if (existingPhases.length > 0) {
+    console.log('Round phases already exist. Skipping seed.');
+    return;
+  }
+
+  console.log('Seeding round phases...');
   for (const phase of roundPhases) {
     await prisma.roundPhase.create({
       data: phase,


### PR DESCRIPTION
## Changes

1. Updated `packages/db/package.json`:
   - Modified `postinstall` script to include database migration and seeding
   - Added new scripts for database management:
     - `db:generate`: Generate Prisma client
     - `db:migrate:dev`: Run development migrations
     - `db:seed`: Run database seeding
     - `db:reset`: Reset the database
     - `nuke`: Force reset the database

2. Refactored `packages/db/prisma/seed.ts`:
   - Introduced `alwaysRunSeeds` array for seeds that should always run
   - Added `nonCISeeds` array for seeds that should not run in CI environment
   - Modified `seed()` function to conditionally run seeds based on environment

3. Updated `packages/db/prisma/seeds/round-phases.ts`:
   - Added check for existing round phases to prevent duplicate seeding
   - Improved logging for better visibility of seeding process

## Rationale

These changes improve our database management workflow and seeding process:

- New scripts provide easier and more consistent database operations
- The updated seeding structure allows for better control over which seeds run in different environments
- Preventing duplicate seeding of round phases ensures data integrity and improves performance

## Testing

- Verify that all new scripts work as expected
- Test the `postinstall` script to ensure it correctly sets up the database
- Confirm that seeding works correctly in both CI and non-CI environments
- Verify that round phases are only seeded once, even on multiple runs

## Notes

- Review the `nonCISeeds` array and add any necessary seeds that should not run in CI
- TODO: Update documentation to reflect new database management scripts